### PR TITLE
fix error parsing value from file with equals

### DIFF
--- a/clara/utils.py
+++ b/clara/utils.py
@@ -125,7 +125,7 @@ def value_from_file(myfile, key):
         for line in hand:
             if key in line:
                 texto = line.rstrip().split("=")
-                password = texto[1].strip('"').strip("'")
+                password = '='.join(texto[1:]).strip('"').strip("'")
     if password == "":
         clara_exit("{0} not found in the file {1}".format(key, myfile))
     return password


### PR DESCRIPTION
When the value searched by value_from_file() contains an equal sign, it
just returns the value before this equals sign. This commit fixes this
by joining all parts of previous the split except the key.