### PR TITLE
virt: introduce getmacs action

### DIFF
--- a/clara/virt/libvirt/vm.py
+++ b/clara/virt/libvirt/vm.py
@@ -226,3 +226,24 @@ class VM():
             for vol in pool_volumes.values():
                 result.append(vol)
         return result
+
+    def get_macs(self, template_name):
+        """Returns a dict of network/mac pairs for the VM."""
+
+        macs = {}  # return result dict
+
+        # merge templtate/vm params into params dict
+        template_params = self.conf.get_template_vm_params(template_name)
+        vm_params = self.conf.get_vm_params(self.name)
+        params = template_params.copy()
+        params.update(vm_params)
+        networks = self.conf.get_vm_networks(self.name, params['network_list'])
+
+        # iterate over the networks
+        for net_name in networks:
+            mac_address = networks[net_name]['mac_address']
+            if mac_address == '':
+                mac_address = self.generate_mac(net_name)
+            macs[net_name] = mac_address
+
+        return macs

--- a/docs/source/clara-virt.md
+++ b/docs/source/clara-virt.md
@@ -12,6 +12,7 @@ clara-virt - manages virtual machines
     clara virt start <vm_names> [--host=<host>] [--wipe] [--virt-config=<path>]
     clara virt stop <vm_names> [--host=<host>] [--hard] [--virt-config=<path>]
     clara virt migrate <vm_names> --dest-host=<dest_host> [--host=<host>] [--virt-config=<path>]
+    clara virt getmacs <vm_names> [--template=<template_name>] [--virt-config=<path>]
     clara virt -h | --help | help
 
 Options:
@@ -64,6 +65,11 @@ use the *--hard* flag to force the shutdown.
 
 Moves a running VM from a host (*--host*) to another (*--dest-host*). The migration is done without
 bringing down the VM. This command is synchronous and only returns when the migration ends.
+
+    clara virt getmacs <vm_names> [--template=<template_name>] [--virt-config=<path>]
+
+Print the MAC addresses of all network interfaces of the VM that Clara set in the VM definition
+file.
 
 # SEE ALSO
 


### PR DESCRIPTION
The new getmacs action prints the MAC addresses defined by Clara of all
the network interfaces of the virtual machines given in argument.

Fix #88