### PR TITLE
ipmi: connect: provide an ssh_jump_host configuration option

### DIFF
--- a/example-conf/config.ini
+++ b/example-conf/config.ini
@@ -50,6 +50,7 @@ conmand=atadmin1
 port=7890
 parallel=12
 prefix=imm
+ssh_jump_host=true
 
 [images]
 ; String: Debian release used as base


### PR DESCRIPTION
This optional configuration permits to use an ssh connexion as a relay to the conman server

The feature permits to hide the conman server behind a secure gateway and have the conman
stream encrypted between the client and the secure gateway.

Signed-off-by: Guillaume Ranquet <guillaume-externe.ranquet@edf.fr>