### PR TITLE
Add docs for plugin virt

### DIFF
--- a/docs/source/clara-virt.md
+++ b/docs/source/clara-virt.md
@@ -11,7 +11,7 @@ clara-virt - manages virtual machines
     clara virt undefine <vm_names> [--host=<host>] [--virt-config=<path>]
     clara virt start <vm_names> [--host=<host>] [--wipe] [--virt-config=<path>]
     clara virt stop <vm_names> [--host=<host>] [--hard] [--virt-config=<path>]
-    clara virt migrate <vm_names> --dest-host=<dest_host> [--host=<host>] [--virt-config=<path>]
+    clara virt migrate <vm_names> [--dest-host=<dest_host>] [--host=<host>] [--virt-config=<path>]
     clara virt getmacs <vm_names> [--template=<template_name>] [--virt-config=<path>]
     clara virt -h | --help | help
 
@@ -126,10 +126,44 @@ starting the virtual machine. This triggers a PXE boot.
 Stops a running VM by requesting a clean shutdown. If this does not succeed, it is possible to
 use the *--hard* flag to force the shutdown.
 
-    clara virt migrate <vm_names> --dest-host=<dest_host> [--host=<host>] [--virt-config=<path>]
+    clara virt migrate [<vm_names>] [--dest-host=<dest_host>] [--host=<host>] [--virt-config=<path>]
 
 Moves a running VM from a host (*--host*) to another (*--dest-host*). The migration is done without
 bringing down the VM. This command is synchronous and only returns when the migration ends.
+
+Migration source host is by default host on which `clara virt migrate` command have been raised.
+But you can also raised it from any cluster KVM server host!
+
+At another part, if not provided, destination host, invoked by *--dest-host* switch,
+can be picked automatically, as the cluster host with lower running VM!
+Let's illustrate it with machine *exbatch2* currently running on server *exservice3*:
+
+```
+clara virt migrate exbatch2
+clara virt list
++------------+----------+---------+
+|       Host | VM       |  State  |
++------------+----------+---------+
+| centos7    |          | MISSING |
++------------+----------+---------+
+| exservice1 |          |         |
++------------+----------+---------+
+|            | exadmin1 | RUNNING |
+|            | exbatch1 | RUNNING |
++------------+----------+---------+
+| exservice2 |          |         |
++------------+----------+---------+
+|            | exp2p2   | SHUTOFF |
+|            | exproxy1 | RUNNING |
++------------+----------+---------+
+| exservice3 |          |         |
++------------+----------+---------+
+|            | exbatch2 | RUNNING |
+|            | exp2p1   | RUNNING |
++------------+----------+---------+
+```
+
+Raising command: `clara virt migrate exbatch2 --dest-host exservice3` would have given same result!
 
     clara virt getmacs <vm_names> [--template=<template_name>] [--virt-config=<path>]
 

--- a/docs/source/clara-virt.md
+++ b/docs/source/clara-virt.md
@@ -6,7 +6,7 @@ clara-virt - manages virtual machines
 
 # SYNOPSIS
 
-    clara virt list [--details] [--virt-config=<path>]
+    clara virt list [--details] [--legacy] [--color] [--host=<host>] [--virt-config=<path>]
     clara virt define <vm_names> --host=<host> [--template=<template_name>] [--virt-config=<path>]
     clara virt undefine <vm_names> [--host=<host>] [--virt-config=<path>]
     clara virt start <vm_names> [--host=<host>] [--wipe] [--virt-config=<path>]
@@ -16,9 +16,12 @@ clara-virt - manages virtual machines
     clara virt -h | --help | help
 
 Options:
+
     <vm_names>                  List of VM names (ClusterShell nodeset)
     <host>                      Physical host where the action should be applied
     --details                   Display details (hosts and volumes)
+    --legacy                    Old School display
+    --color                     Colorize or not output
     --wipe                      Wipe the content of the storage volume before starting
     --hard                      Perform a hard shutdown
     --dest-host=<dest_host>     Destination host of a migration
@@ -35,10 +38,72 @@ This plugins requires LibVirt >= 10.2.9 (version in Debian 8).
 
 # OPTIONS
 
-    clara virt list [--details] [--virt-config=<path>]
+    clara virt list [--details] [--legacy] [--color] \
+                    [--host=<host>] [--virt-config=<path>]
 
-List the machines. If *--details* is provided: where instances are running and storages
-volumes associated.
+List the KVM cluster machines in two way.\
+The first one as *table*, as show bellow:
+
+```
+clara virt list
++------------+----------+---------+
+|       Host | VM       |  State  |
++------------+----------+---------+
+| centos7    |          | MISSING |
++------------+----------+---------+
+| exservice1 |          |         |
++------------+----------+---------+
+|            | exadmin1 | RUNNING |
+|            | exbatch1 | RUNNING |
++------------+----------+---------+
+| exservice2 |          |         |
++------------+----------+---------+
+|            | exbatch2 | RUNNING |
+|            | exp2p2   | SHUTOFF |
+|            | exproxy1 | RUNNING |
++------------+----------+---------+
+| exservice3 |          |         |
++------------+----------+---------+
+|            | exp2p1   | RUNNING |
++------------+----------+---------+
+```
+
+The second way is available through switch *--legacy*:
+
+```
+clara virt list --legacy
+VM:exadmin1         State:RUNNING      Host:exservice1
+VM:exbatch1         State:RUNNING      Host:exservice1
+VM:exbatch2         State:RUNNING      Host:exservice2
+VM:exp2p2           State:SHUTOFF      Host:exservice2
+VM:exproxy1         State:RUNNING      Host:exservice2
+VM:exp2p1           State:RUNNING      Host:exservice3
+VM:centos7          State:MISSING      Host:
+```
+
+. If *--details* is provided, bellow additional informations are given:
+- where instances are running and storages volumes associated.
+- machines (VMs) allocated memory and cpu.
+- KVM server hosts total memory and cpu and addition \
+  of memory and cpu on all hosted machines.
+
+For instance, say a server host, exservice1, with 8 cpu and 16 Go of memory,\
+with two machines:
+
+    exadmin1: 4 allocated cpus and 4 Go of memory
+    exbatch1: 6 cpus and 8 Go of memory
+
+```
+clara virt list --details --host=exservice1
++------------+----------+---------+---------+-------+-----------------+----------+----------+
+|       Host | VM       |  State  |  memory |  cpus |        Volume   |   Pool   | Capacity |
++------------+----------+---------+---------+-------+-----------------+----------+----------+
+| exservice1 |          |         |  12/8   | 10/8  |                 |          |          |
++------------+----------+---------+---------+-------+-----------------+----------+----------+
+|            | exadmin1 | RUNNING |    4    |   4   | exadmin1_system | rbd-pool | 40.0 GB  |
+|            | exbatch1 | RUNNING |    8    |   6   | exbatch1_system | rbd-pool | 100.0 GB |
++------------+----------+---------+---------+-------+-----------------+----------+----------+
+```
 
     clara virt define <vm_names> --host=<host> [--template=<template_name>] [--virt-config=<path>]
 

--- a/docs/source/clara.md
+++ b/docs/source/clara.md
@@ -26,8 +26,8 @@ as plugins that can be added or removed independently.
 
 Clara provides the following plugins:
 
-    repo     Creates, updates and synchronizes local Debian repositories.
     ipmi     Manages and get the status from the nodes of a cluster.
+    repo     Creates, updates and synchronizes local Debian and RedHat like repositories.
     slurm    Performs tasks using SLURM's controller.
     images   Creates and updates the images of installation of a cluster.
     chroot   Creates and updates a chroot. 

--- a/docs/source/clara.md
+++ b/docs/source/clara.md
@@ -34,7 +34,8 @@ Clara provides the following plugins:
     p2p      Makes torrent images and seeds them via BitTorrent.
     enc      Interact with encrypted files using configurable methods.
     build    Builds Debian packages.
+    show     Show the set of configuration used in config.ini.
 
 # SEE ALSO
 
-clara-images(1), clara-ipmi(1), clara-p2p(1), clara-repo(1), clara-slurm(1), clara-enc(1), clara-build(1), clara-virt(1), clara-chroot(1)
+clara-images(1), clara-ipmi(1), clara-p2p(1), clara-repo(1), clara-slurm(1), clara-enc(1), clara-build(1), clara-virt(1), clara-chroot(1), clara-show(1)

--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -693,21 +693,26 @@ This plugins requires LibVirt >= 10.2.9 (version in Debian 8).
     clara virt undefine <vm_names> [--host=<host>] [--virt-config=<path>]
     clara virt start <vm_names> [--host=<host>] [--wipe] [--virt-config=<path>]
     clara virt stop <vm_names> [--host=<host>] [--hard] [--virt-config=<path>]
-    clara virt migrate <vm_names> --dest-host=<dest_host> [--host=<host>] [--virt-config=<path>]
+    clara virt migrate [<vm_names>] [--dest-host=<dest_host>] [--host=<host>] [--virt-config=<path>] [--dry-run] [--quiet] [--yes-i-really-really-mean-it] [--exclude=<exclude>] [--include=<include>]
     clara virt -h | --help | help
 
 Options:
 
-    <vm_names>                  List of VM names (ClusterShell nodeset)
-    <host>                      Physical host where the action should be applied
-    --details                   Display details (hosts and volumes)
-    --legacy                    Old School display
-    --color                     Colorize or not output
-    --wipe                      Wipe the content of the storage volume before starting
-    --hard                      Perform a hard shutdown
-    --dest-host=<dest_host>     Destination host of a migration
-    --template=<template_name>  Use this template instead of the in config
-    --virt-config=<path>        Path of the virt config file [default: /etc/clara/virt.ini]
+    <vm_names>                     List of VM names (ClusterShell nodeset)
+    <host>                         Physical host where the action should be applied
+    --details                      Display details (hosts and volumes)
+    --legacy                       Old School display
+    --color                        Colorize or not output
+    --wipe                         Wipe the content of the storage volume before starting
+    --hard                         Perform a hard shutdown
+    --dest-host=<dest_host>        Destination host of a migration
+    --template=<template_name>     Use this template instead of the in config
+    --virt-config=<path>           Path of the virt config file [default: /etc/clara/virt.ini]
+    --quiet                        Proceed silencely. Don't ask any question!
+    --dry-run                      Just simulate migrate action! Don't really do anything
+    --yes-i-really-really-mean-it  Force migrate action execution without any further validation
+    --exclude=<exclude>            Exclude pattern in VMs [default: service]
+    --include=<include>            Include pattern in VMs
 
 ## Options
 
@@ -746,13 +751,24 @@ starting the virtual machine. This triggers a PXE boot.
 Stops a running VM by requesting a clean shutdown. If this does not succeed, it is possible to
 use the *--hard* flag to force the shutdown.
 
-    clara virt migrate [<vm_names>] --dest-host=<dest_host> [--host=<host>] [--virt-config=<path>]
+    clara virt migrate [<vm_names>] [--dest-host=<dest_host>] \
+    [--host=<host>] [--virt-config=<path>] [--dry-run] [--quiet] \
+    [--yes-i-really-really-mean-it] [--exclude=<exclude>] [--include=<include>]
 
 Moves a running VM from a host (*--host*) to another (*--dest-host*). The migration is done without
 bringing down the VM. This command is synchronous and only returns when the migration ends.
 
-Migration source host is by default host on which `clara virt migrate` command have been raised.\
-But you can also raised it from any cluster KVM server host!
+Live migration can been simulated using optional switch *--dry-run*.
 
-At another part, if not provided, destination host, invoked by *--dest-host* switch,
+In another word, when machines involved in migration have been provided through *<vm_names>*,\
+live migration are really done unless switch *--dry-run* have been raised!
+
+Migration source host is, by default, the host on which `clara virt migrate` command \
+have been raised. But you can also raised it from any cluster KVM server host!
+
+At another part, if not provided, destination host, invoked by *--dest-host* switch,\
 can be picked automatically, as the cluster host with lower running VM!
+
+Machines involved in live migration are optional and when not provided, all running
+machines will be migrated off KVM server on witch command have been raised.
+This can be seen as a kind of machines *evacuation*!

--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -1,6 +1,6 @@
 % Clara User's Guide
-% Ana Guerrero Lopez
-% October 13, 2016
+% Kwame AMEDODJI
+% January 02, 2024
 
 # What's Clara?
 
@@ -89,6 +89,7 @@ example.
        enc      Interact with encrypted files using configurable methods.
        build    Builds Debian packages.
        virt     Manages virtual machines.
+       show     Show the set of configuration used in config.ini.
 
     See 'clara help <plugin>' for detailed help on a plugin
     and 'clara <plugin> --help' for a quick list of options of a plugin.

--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -688,7 +688,7 @@ This plugins requires LibVirt >= 10.2.9 (version in Debian 8).
 
 ### Synopsis
 
-    clara virt list [--details] [--virt-config=<path>]
+    clara virt list [--details] [--legacy] [--color] [--host=<host>] [--virt-config=<path>]
     clara virt define <vm_names> --host=<host> [--template=<template_name>] [--virt-config=<path>]
     clara virt undefine <vm_names> [--host=<host>] [--virt-config=<path>]
     clara virt start <vm_names> [--host=<host>] [--wipe] [--virt-config=<path>]
@@ -697,9 +697,12 @@ This plugins requires LibVirt >= 10.2.9 (version in Debian 8).
     clara virt -h | --help | help
 
 Options:
+
     <vm_names>                  List of VM names (ClusterShell nodeset)
     <host>                      Physical host where the action should be applied
     --details                   Display details (hosts and volumes)
+    --legacy                    Old School display
+    --color                     Colorize or not output
     --wipe                      Wipe the content of the storage volume before starting
     --hard                      Perform a hard shutdown
     --dest-host=<dest_host>     Destination host of a migration
@@ -708,12 +711,21 @@ Options:
 
 ## Options
 
-    clara virt list [--details] [--virt-config=<path>]
+    clara virt list [--details] [--legacy] [--color] \
+                    [--host=<host>] [--virt-config=<path>]
 
-List the machines. If *--details* is provided: where instances are running and storages
-volumes associated.
+List the KVM cluster machines in two way. The first one as a *pretty table*,\
+and the second as a flat raw display.
 
-    clara virt define <vm_names> --host=<host> [--template=<template_name>] [--virt-config=<path>]
+If *--details* is provided, bellow additional informations are given:
+- where instances are running and storages volumes associated.
+- machines (VMs) allocated memory and cpu.
+- KVM server hosts total memory and cpu and addition \
+  of memory and cpu on all hosted machines.
+
+```
+clara virt define <vm_names> --host=<host> [--template=<template_name>] [--virt-config=<path>]
+```
 
 Define a VM on *host*, the description of the vm is read from a template in the configuration.
 The template is chosen in this order: *--template* argument, name matching in the conf, template

--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -746,7 +746,13 @@ starting the virtual machine. This triggers a PXE boot.
 Stops a running VM by requesting a clean shutdown. If this does not succeed, it is possible to
 use the *--hard* flag to force the shutdown.
 
-    clara virt migrate <vm_names> --dest-host=<dest_host> [--host=<host>] [--virt-config=<path>]
+    clara virt migrate [<vm_names>] --dest-host=<dest_host> [--host=<host>] [--virt-config=<path>]
 
 Moves a running VM from a host (*--host*) to another (*--dest-host*). The migration is done without
 bringing down the VM. This command is synchronous and only returns when the migration ends.
+
+Migration source host is by default host on which `clara virt migrate` command have been raised.\
+But you can also raised it from any cluster KVM server host!
+
+At another part, if not provided, destination host, invoked by *--dest-host* switch,
+can be picked automatically, as the cluster host with lower running VM!


### PR DESCRIPTION
docs: add support to redhat-like repositories 
docs: automatic VM live migrate and dry run mode 
docs: migrate to automatic pick destination host 
docs: enhanced virt plugin with cpu/mem details 
docs: add forgotten show plugin 
